### PR TITLE
Fix/cv2 objects rotation

### DIFF
--- a/PyTest/test_drawObjects_angle.py
+++ b/PyTest/test_drawObjects_angle.py
@@ -1,0 +1,84 @@
+import cv2, numpy as np, math, pytest
+
+class DummyPC:
+    def tgcToCV2(self, x, z, image_scale):
+        return int(z / image_scale), int(x / image_scale)
+
+def draw_ellipse_like_objects(im, pc, x, z, sx, sz, ry, use_radians=False):
+    image_scale = 1.0
+    center_cv = pc.tgcToCV2(x, z, image_scale)
+    center = (center_cv[1], center_cv[0])
+    width  = sx / image_scale
+    height = sz / image_scale
+    if use_radians:
+        rotation = - ry * math.pi / 180.0  # BUG: radians passed as degrees
+    else:
+        rotation = -float(ry)              # FIX: degrees (clockwise)
+    cv2.ellipse(im, (center, (width, height), rotation), (255,255,255), thickness=-1, lineType=cv2.LINE_AA)
+
+def measured_angle_deg(im):
+    gray = cv2.cvtColor(im, cv2.COLOR_BGR2GRAY)
+    _, mask = cv2.threshold(gray, 1, 255, cv2.THRESH_BINARY)
+    cnts, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_NONE)
+    cnt = max(cnts, key=cv2.contourArea)
+    (cx, cy), (MA, ma), angle = cv2.fitEllipse(cnt)
+    return angle % 180.0
+
+def ang_close(a, b, tol=5.0):
+    # shortest distance on a circle of 180 degrees
+    d = abs(((a - b + 90) % 180) - 90)
+    return d <= tol
+
+@pytest.mark.parametrize("ry", [15, 30, 60, 90, 120])
+def test_objects_rotation_convention(ry):
+    H, W = 500, 500
+    pc = DummyPC()
+    x, z = 250, 250
+    sx, sz = 280, 80  # width >= height -> use the (90 + rotation) rule
+
+    # Buggy draw (radians)
+    bug = np.zeros((H, W, 3), np.uint8)
+    draw_ellipse_like_objects(bug, pc, x, z, sx, sz, ry, use_radians=True)
+    bug_angle = measured_angle_deg(bug)
+
+    # Fixed draw (degrees)
+    fix = np.zeros((H, W, 3), np.uint8)
+    draw_ellipse_like_objects(fix, pc, x, z, sx, sz, ry, use_radians=False)
+    fix_angle = measured_angle_deg(fix)
+
+    rotation_cw_deg = -float(ry)
+    if sx >= sz:
+        expected = (90.0 + rotation_cw_deg) % 180.0   # == (90 - ry) % 180
+    else:
+        expected = (rotation_cw_deg) % 180.0
+
+    assert ang_close(fix_angle, expected), f"fixed angle {fix_angle:.2f} not close to expected {expected:.2f} for ry={ry}"
+    assert not ang_close(bug_angle, expected), f"bug angle {bug_angle:.2f} unexpectedly close to expected {expected:.2f} for ry={ry}"
+
+
+
+def unwrap180(a):
+    # map to a continuous line so we can compare differences
+    return a  # good enough for small deltas in this test
+
+def test_fixed_changes_with_ry_but_bug_does_not():
+    pc = DummyPC()
+    H, W = 400, 400
+    x, z = 200, 200
+    sx, sz = 280, 80
+
+    def angle_for(ry, use_radians):
+        im = np.zeros((H, W, 3), np.uint8)
+        draw_ellipse_like_objects(im, pc, x, z, sx, sz, ry, use_radians=use_radians)
+        return measured_angle_deg(im)
+
+    a1_fix = unwrap180(angle_for(10, False))
+    a2_fix = unwrap180(angle_for(40, False))
+    a1_bug = unwrap180(angle_for(10, True))
+    a2_bug = unwrap180(angle_for(40, True))
+
+    # Fixed should change by ~30 deg (allow slack for sampling AA etc.)
+    assert abs(((a2_fix - a1_fix + 90) % 180) - 90) >= 20.0
+
+    # Bug should change very little (radians mistaken as degrees)
+    assert abs(((a2_bug - a1_bug + 90) % 180) - 90) <= 5.0

--- a/file-version.txt
+++ b/file-version.txt
@@ -1,8 +1,8 @@
 # UTF-8
 VSVersionInfo(
   ffi=FixedFileInfo(
-    filevers=(0, 4, 1, 0),
-    prodvers=(0, 4, 1, 0),
+    filevers=(0, 4, 3, 0),
+    prodvers=(0, 4, 3, 0),
     mask=0x3f,
     flags=0x0,
     fileType=0x1,      # VFT_APP

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ scikit-image==0.25.0
 scipy==1.12.0
 urllib3==2.3.0
 laspy[lazrs,laszip]==2.6.1
+pytest==8.4.1

--- a/tgc_visualizer.py
+++ b/tgc_visualizer.py
@@ -174,8 +174,12 @@ def drawObjectsOnImage(objects, color, im, pc, image_scale):
                 continue
 
             ry = rot.get("y", 0)
-            # NOTE: keeping existing behavior: rotation converted to radians
-            rotation = - ry * math.pi / 180.0
+            
+            try:
+                ry = float(ry)
+            except (TypeError, ValueError):
+                continue  # skip malformed rotation
+            rotation = -ry  # degrees, clockwise for OpenCV
 
             bounding_box = (center, (width, height), rotation)
             cv2.ellipse(im, bounding_box, color, thickness=-1, lineType=cv2.LINE_AA)

--- a/tgc_visualizer.py
+++ b/tgc_visualizer.py
@@ -143,8 +143,12 @@ def drawObjectsOnImage(objects, color, im, pc, image_scale):
                 continue
 
             ry = rot.get("y", 0)
-            # NOTE: keeping existing behavior: rotation converted to radians
-            rotation = - ry * math.pi / 180.0
+
+            try:
+                ry = float(ry)
+            except (TypeError, ValueError):
+                continue  # skip malformed rotation
+            rotation = -ry  # degrees, clockwise for OpenCV
 
             bounding_box = (center, (width, height), rotation)
             cv2.ellipse(im, bounding_box, color, thickness=-1, lineType=cv2.LINE_AA)


### PR DESCRIPTION
In tgc_visualizer.py, fix drawObjectsOnImage to use degrees instead of radians.  This function then complies with similar function drawBrushesOnImage(), which uses degrees.