### PR TITLE
Fix OSM KeyError; Advance version to 0.4.4

### DIFF
--- a/file-version.txt
+++ b/file-version.txt
@@ -1,8 +1,8 @@
 # UTF-8
 VSVersionInfo(
   ffi=FixedFileInfo(
-    filevers=(0, 4, 1, 0),
-    prodvers=(0, 4, 1, 0),
+    filevers=(0, 4, 4, 0),
+    prodvers=(0, 4, 4, 0),
     mask=0x3f,
     flags=0x0,
     fileType=0x1,      # VFT_APP
@@ -16,11 +16,11 @@ VSVersionInfo(
         [
           StringStruct(u"CompanyName", u"Steve Hibbert"),
           StringStruct(u"FileDescription", u"TGC-Designer-Tools (2025 community fork)"),
-          StringStruct(u"FileVersion", u"0.4.2.0"),
+          StringStruct(u"FileVersion", u"0.4.4.0"),
           StringStruct(u"InternalName", u"TGC-Designer-Tools.exe"),
           StringStruct(u"OriginalFilename", u"TGC-Designer-Tools.exe"),
           StringStruct(u"ProductName", u"TGC-Designer-Tools"),
-          StringStruct(u"ProductVersion", u"0.4.2")
+          StringStruct(u"ProductVersion", u"0.4.4.0")
         ]
       )
     ]),

--- a/tgc_gui.py
+++ b/tgc_gui.py
@@ -20,7 +20,7 @@ import tgc_image_terrain
 from tgc_visualizer import drawCourseAsImage
 import OSMTGC
 
-TGC_GUI_VERSION = "0.4.2"
+TGC_GUI_VERSION = "0.4.4"
 
 image_width = 500
 image_height = 500


### PR DESCRIPTION
Error raised on TGC Proboards by houseofmogh420, an error during OSM interaction, for an OSM element that does not exist.

Fix updates addOSMToTGC() to handle missing keys.