### PR TITLE
Fix Overpass 406 by sending custom headers

### DIFF
--- a/OSMTGC.py
+++ b/OSMTGC.py
@@ -6,6 +6,7 @@ import math
 import numpy as np
 import overpy
 import time
+import overpass_with_headers
 
 
 import tgc_definitions
@@ -450,7 +451,8 @@ def newHole(userpar, points, course_version):
     return hole
 
 def getOSMData(bottom_lat, left_lon, top_lat, right_lon, printf=print):
-    op = overpy.Overpass()
+    op = overpass_with_headers.OverpassWithHeaders() # Adds header to solve 406 error
+
     # Order is South, West, North, East
     coord_string = str(bottom_lat) + "," + str(left_lon) + "," + str(top_lat) + "," + str(right_lon)
 

--- a/overpass_with_headers.py
+++ b/overpass_with_headers.py
@@ -1,0 +1,46 @@
+# Overpass OSM API has been amended to require additional Header data.
+# This module sub-classes the Overpass module to add minimal extension without altering the public class.
+#
+import overpy
+from urllib.request import Request, urlopen
+from urllib.error import HTTPError
+
+
+class OverpassWithHeaders(overpy.Overpass):
+    def query(self, query):
+        if not isinstance(query, bytes):
+            query = query.encode("utf-8")
+
+        req = Request(
+            self.url,
+            data=query,
+            headers={
+                "User-Agent": "ChadsTool/1.0 (contact: hiblet@yahoo.com)",
+                "Accept": "application/json",
+                "Content-Type": "application/x-www-form-urlencoded; charset=utf-8",
+            },
+            method="POST",
+        )
+
+        response = b""
+
+        try:
+            with urlopen(req) as f:
+                while True:
+                    chunk = f.read(self.read_chunk_size)
+                    if not chunk:
+                        break
+                    response += chunk
+
+                content_type = f.getheader("Content-Type") or ""
+
+        except HTTPError as exc:
+            err_body = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(
+                f"Overpass HTTP {exc.code}. Body: {err_body[:2000]}"
+            ) from exc
+
+        if "json" in content_type.lower():
+            return self.parse_json(response)
+
+        return self.parse_xml(response)


### PR DESCRIPTION
Fix 406 error and update version.

Fixed by sub-classing Overpy with a local module sub-class, and changing OSMTGC.py:getOSMData() to instantiate the new sub-class.